### PR TITLE
feat: Namespace API under /api and add basic web UI

### DIFF
--- a/todo_backend/static/index.html
+++ b/todo_backend/static/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Todo App</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>Todo List</h1>
+    <input type="text" id="todo-description" placeholder="Enter new todo">
+    <button id="add-todo">Add Todo</button>
+    <ul id="todo-list">
+        <!-- Todos will be listed here -->
+    </ul>
+    <script src="/static/script.js"></script>
+</body>
+</html>

--- a/todo_backend/static/script.js
+++ b/todo_backend/static/script.js
@@ -1,0 +1,105 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const todoDescriptionInput = document.getElementById('todo-description');
+    const addTodoButton = document.getElementById('add-todo');
+    const todoList = document.getElementById('todo-list');
+
+    const apiUrl = '/api/todos';
+
+    async function fetchTodos() {
+        try {
+            const response = await fetch(apiUrl);
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            const todos = await response.json();
+            renderTodos(todos);
+        } catch (error) {
+            console.error("Failed to fetch todos:", error);
+            todoList.innerHTML = '<li>Failed to load todos.</li>';
+        }
+    }
+
+    function renderTodos(todos) {
+        todoList.innerHTML = ''; // Clear existing todos
+        if (todos.length === 0) {
+            todoList.innerHTML = '<li>No todos yet.</li>';
+            return;
+        }
+        todos.forEach(todo => {
+            const listItem = document.createElement('li');
+            listItem.textContent = todo.description;
+            if (todo.completed) {
+                listItem.classList.add('completed');
+            }
+
+            const completeButton = document.createElement('button');
+            completeButton.textContent = 'Complete';
+            completeButton.classList.add('complete-btn');
+            completeButton.onclick = async () => {
+                if (!todo.completed) {
+                    await completeTodoItem(todo.id);
+                }
+            };
+            if (todo.completed) {
+                completeButton.disabled = true;
+                completeButton.textContent = 'Completed';
+            }
+
+
+            listItem.appendChild(completeButton);
+            todoList.appendChild(listItem);
+        });
+    }
+
+    async function addTodoItem() {
+        const description = todoDescriptionInput.value.trim();
+        if (!description) {
+            alert('Please enter a todo description.');
+            return;
+        }
+
+        try {
+            const response = await fetch(apiUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ description }),
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            // const newTodo = await response.json(); // Not strictly needed to re-render from this
+            todoDescriptionInput.value = ''; // Clear input
+            fetchTodos(); // Refresh the list
+        } catch (error) {
+            console.error("Failed to add todo:", error);
+            alert('Failed to add todo.');
+        }
+    }
+
+    async function completeTodoItem(id) {
+        try {
+            const response = await fetch(`${apiUrl}/${id}/complete`, {
+                method: 'PUT',
+            });
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            fetchTodos(); // Refresh the list
+        } catch (error) {
+            console.error(`Failed to complete todo ${id}:`, error);
+            alert(`Failed to complete todo ${id}.`);
+        }
+    }
+
+    addTodoButton.addEventListener('click', addTodoItem);
+    todoDescriptionInput.addEventListener('keypress', (event) => {
+        if (event.key === 'Enter') {
+            addTodoItem();
+        }
+    });
+
+    // Initial fetch of todos
+    fetchTodos();
+});

--- a/todo_backend/static/style.css
+++ b/todo_backend/static/style.css
@@ -1,0 +1,57 @@
+body {
+    font-family: sans-serif;
+    margin: 20px;
+    background-color: #f4f4f4;
+}
+
+h1 {
+    color: #333;
+}
+
+input[type="text"] {
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    width: calc(100% - 100px); /* Adjust width considering the button */
+    margin-right: 10px;
+}
+
+button {
+    padding: 10px 15px;
+    background-color: #5cb85c;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button:hover {
+    background-color: #4cae4c;
+}
+
+ul {
+    list-style-type: none;
+    padding: 0;
+}
+
+li {
+    background-color: #fff;
+    padding: 10px;
+    border-bottom: 1px solid #ddd;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+li.completed {
+    text-decoration: line-through;
+    color: #aaa;
+}
+
+li button.complete-btn {
+    background-color: #337ab7;
+    margin-left: 10px;
+}
+li button.complete-btn:hover {
+    background-color: #286090;
+}

--- a/todo_backend/tests/test_main.rs
+++ b/todo_backend/tests/test_main.rs
@@ -21,7 +21,7 @@ mod tests {
     fn test_add_todo() {
         let client = test_client();
         let description = "Test todo item - add";
-        let response = client.post("/todos")
+        let response = client.post("/api/todos")
             .header(ContentType::JSON)
             .body(json!({ "description": description }).to_string())
             .dispatch();
@@ -41,7 +41,7 @@ mod tests {
         let description = "Test todo item - get";
 
         // Add an item first
-        let add_response = client.post("/todos")
+        let add_response = client.post("/api/todos")
             .header(ContentType::JSON)
             .body(json!({ "description": description }).to_string())
             .dispatch();
@@ -50,7 +50,7 @@ mod tests {
         let item_id = added_item.id;
 
         // Test retrieving the existing item
-        let response = client.get(format!("/todos/{}", item_id)).dispatch();
+        let response = client.get(format!("/api/todos/{}", item_id)).dispatch();
         assert_eq!(response.status(), Status::Ok);
         let fetched_item = response.into_json::<TodoItem>().unwrap();
         assert_eq!(fetched_item.id, item_id);
@@ -59,7 +59,7 @@ mod tests {
         // Test retrieving a non-existing item
         let non_existing_id = AppUuid::new_v4(); // Use AppUuid here
         // AppUuid will deref to Uuid, which implements Display for the format macro
-        let response_not_found = client.get(format!("/todos/{}", non_existing_id)).dispatch();
+        let response_not_found = client.get(format!("/api/todos/{}", non_existing_id)).dispatch();
         assert_eq!(response_not_found.status(), Status::NotFound);
     }
 
@@ -69,7 +69,7 @@ mod tests {
         let description = "Test todo item - complete";
 
         // Add an item first
-        let add_response = client.post("/todos")
+        let add_response = client.post("/api/todos")
             .header(ContentType::JSON)
             .body(json!({ "description": description }).to_string())
             .dispatch();
@@ -78,14 +78,14 @@ mod tests {
         let item_id = added_item.id;
 
         // Mark the item as complete
-        let complete_response = client.put(format!("/todos/{}/complete", item_id)).dispatch();
+        let complete_response = client.put(format!("/api/todos/{}/complete", item_id)).dispatch();
         assert_eq!(complete_response.status(), Status::Ok);
         let completed_item = complete_response.into_json::<TodoItem>().unwrap();
         assert_eq!(completed_item.id, item_id);
         assert!(completed_item.completed);
 
         // Verify it's completed by getting it again
-        let get_response = client.get(format!("/todos/{}", item_id)).dispatch();
+        let get_response = client.get(format!("/api/todos/{}", item_id)).dispatch();
         assert_eq!(get_response.status(), Status::Ok);
         let fetched_item = get_response.into_json::<TodoItem>().unwrap();
         assert!(fetched_item.completed);
@@ -93,7 +93,7 @@ mod tests {
         // Test completing a non-existing item
         let non_existing_id = AppUuid::new_v4(); // Use AppUuid here
         // AppUuid will deref to Uuid, which implements Display for the format macro
-        let response_not_found = client.put(format!("/todos/{}/complete", non_existing_id)).dispatch();
+        let response_not_found = client.put(format!("/api/todos/{}/complete", non_existing_id)).dispatch();
         assert_eq!(response_not_found.status(), Status::NotFound);
     }
 
@@ -101,12 +101,12 @@ mod tests {
     fn test_search_todos() {
         let client = test_client();
         // Add some items
-        client.post("/todos").header(ContentType::JSON).body(json!({ "description": "Learn Rust" }).to_string()).dispatch();
-        client.post("/todos").header(ContentType::JSON).body(json!({ "description": "Learn Rocket" }).to_string()).dispatch();
-        client.post("/todos").header(ContentType::JSON).body(json!({ "description": "Build an API" }).to_string()).dispatch();
+        client.post("/api/todos").header(ContentType::JSON).body(json!({ "description": "Learn Rust" }).to_string()).dispatch();
+        client.post("/api/todos").header(ContentType::JSON).body(json!({ "description": "Learn Rocket" }).to_string()).dispatch();
+        client.post("/api/todos").header(ContentType::JSON).body(json!({ "description": "Build an API" }).to_string()).dispatch();
 
         // Test search with a query (case-insensitive)
-        let response = client.get("/todos/search?description=learn").dispatch();
+        let response = client.get("/api/todos/search?description=learn").dispatch();
         assert_eq!(response.status(), Status::Ok);
         let items = response.into_json::<Vec<TodoItem>>().unwrap();
         assert_eq!(items.len(), 2);
@@ -114,20 +114,20 @@ mod tests {
         assert!(items.iter().any(|item| item.description == "Learn Rocket"));
 
         // Test search with a query that matches part of a word
-        let response_partial = client.get("/todos/search?description=rock").dispatch();
+        let response_partial = client.get("/api/todos/search?description=rock").dispatch();
         assert_eq!(response_partial.status(), Status::Ok);
         let items_partial = response_partial.into_json::<Vec<TodoItem>>().unwrap();
         assert_eq!(items_partial.len(), 1);
         assert_eq!(items_partial[0].description, "Learn Rocket");
 
         // Test search with a query that matches nothing
-        let response_none = client.get("/todos/search?description=python").dispatch();
+        let response_none = client.get("/api/todos/search?description=python").dispatch();
         assert_eq!(response_none.status(), Status::Ok);
         let items_none = response_none.into_json::<Vec<TodoItem>>().unwrap();
         assert_eq!(items_none.len(), 0);
 
         // Test search with no query (should return all)
-        let response_all = client.get("/todos/search").dispatch();
+        let response_all = client.get("/api/todos/search").dispatch();
         assert_eq!(response_all.status(), Status::Ok);
         let items_all = response_all.into_json::<Vec<TodoItem>>().unwrap();
         assert_eq!(items_all.len(), 3);
@@ -137,17 +137,17 @@ mod tests {
     fn test_list_todos_by_status() {
         let client = test_client();
         // Add items
-        let r1 = client.post("/todos").header(ContentType::JSON).body(json!({ "description": "Pending Task" }).to_string()).dispatch();
+        let r1 = client.post("/api/todos").header(ContentType::JSON).body(json!({ "description": "Pending Task" }).to_string()).dispatch();
         let _item1_id = r1.into_json::<TodoItem>().unwrap().id; // item1_id is AppUuid
-        client.post("/todos").header(ContentType::JSON).body(json!({ "description": "Another Pending" }).to_string()).dispatch();
+        client.post("/api/todos").header(ContentType::JSON).body(json!({ "description": "Another Pending" }).to_string()).dispatch();
 
-        let r3 = client.post("/todos").header(ContentType::JSON).body(json!({ "description": "Completed Task" }).to_string()).dispatch();
+        let r3 = client.post("/api/todos").header(ContentType::JSON).body(json!({ "description": "Completed Task" }).to_string()).dispatch();
         let item3_id = r3.into_json::<TodoItem>().unwrap().id; // item3_id is AppUuid
-        client.put(format!("/todos/{}/complete", item3_id)).dispatch();
+        client.put(format!("/api/todos/{}/complete", item3_id)).dispatch();
 
 
         // Test list with completed=true
-        let response_true = client.get("/todos?completed=true").dispatch();
+        let response_true = client.get("/api/todos?completed=true").dispatch();
         assert_eq!(response_true.status(), Status::Ok);
         let items_true = response_true.into_json::<Vec<TodoItem>>().unwrap();
         assert_eq!(items_true.len(), 1);
@@ -155,14 +155,14 @@ mod tests {
         assert_eq!(items_true[0].description, "Completed Task");
 
         // Test list with completed=false
-        let response_false = client.get("/todos?completed=false").dispatch();
+        let response_false = client.get("/api/todos?completed=false").dispatch();
         assert_eq!(response_false.status(), Status::Ok);
         let items_false = response_false.into_json::<Vec<TodoItem>>().unwrap();
         assert_eq!(items_false.len(), 2);
         assert!(items_false.iter().all(|item| !item.completed));
 
         // Test list with no status (should return all)
-        let response_all = client.get("/todos").dispatch();
+        let response_all = client.get("/api/todos").dispatch();
         assert_eq!(response_all.status(), Status::Ok);
         let items_all = response_all.into_json::<Vec<TodoItem>>().unwrap();
         assert_eq!(items_all.len(), 3);
@@ -172,15 +172,15 @@ mod tests {
     fn test_get_todos_count() {
         let client = test_client();
         // Initial count
-        let response = client.get("/todos/count").dispatch();
+        let response = client.get("/api/todos/count").dispatch();
         assert_eq!(response.status(), Status::Ok);
         assert_eq!(response.into_json::<usize>().unwrap(), 0);
 
         // Add items and check count
-        client.post("/todos").header(ContentType::JSON).body(json!({ "description": "Item 1" }).to_string()).dispatch();
-        client.post("/todos").header(ContentType::JSON).body(json!({ "description": "Item 2" }).to_string()).dispatch();
+        client.post("/api/todos").header(ContentType::JSON).body(json!({ "description": "Item 1" }).to_string()).dispatch();
+        client.post("/api/todos").header(ContentType::JSON).body(json!({ "description": "Item 2" }).to_string()).dispatch();
 
-        let response_after_add = client.get("/todos/count").dispatch();
+        let response_after_add = client.get("/api/todos/count").dispatch();
         assert_eq!(response_after_add.status(), Status::Ok);
         assert_eq!(response_after_add.into_json::<usize>().unwrap(), 2);
     }
@@ -189,21 +189,21 @@ mod tests {
     fn test_get_todos_count_by_status() {
         let client = test_client();
         // Add items
-        let r1 = client.post("/todos").header(ContentType::JSON).body(json!({ "description": "Count Pending 1" }).to_string()).dispatch();
+        let r1 = client.post("/api/todos").header(ContentType::JSON).body(json!({ "description": "Count Pending 1" }).to_string()).dispatch();
         let _item1_id = r1.into_json::<TodoItem>().unwrap().id;
-        client.post("/todos").header(ContentType::JSON).body(json!({ "description": "Count Pending 2" }).to_string()).dispatch();
+        client.post("/api/todos").header(ContentType::JSON).body(json!({ "description": "Count Pending 2" }).to_string()).dispatch();
 
-        let r3 = client.post("/todos").header(ContentType::JSON).body(json!({ "description": "Count Completed 1" }).to_string()).dispatch();
+        let r3 = client.post("/api/todos").header(ContentType::JSON).body(json!({ "description": "Count Completed 1" }).to_string()).dispatch();
         let item3_id = r3.into_json::<TodoItem>().unwrap().id;
-        client.put(format!("/todos/{}/complete", item3_id)).dispatch();
+        client.put(format!("/api/todos/{}/complete", item3_id)).dispatch();
 
         // Test count with completed=true
-        let response_true = client.get("/todos/count?completed=true").dispatch();
+        let response_true = client.get("/api/todos/count?completed=true").dispatch();
         assert_eq!(response_true.status(), Status::Ok);
         assert_eq!(response_true.into_json::<usize>().unwrap(), 1);
 
         // Test count with completed=false
-        let response_false = client.get("/todos/count?completed=false").dispatch();
+        let response_false = client.get("/api/todos/count?completed=false").dispatch();
         assert_eq!(response_false.status(), Status::Ok);
         assert_eq!(response_false.into_json::<usize>().unwrap(), 2);
     }


### PR DESCRIPTION
This commit introduces two major changes:

1. API Namespacing:
   - All existing To-Do API endpoints have been moved from the root path (/) to be prefixed with /api. For example, /todos is now /api/todos.
   - This change was made by updating the mount point in `todo_backend/src/lib.rs`.
   - Integration tests in `todo_backend/tests/test_main.rs` have been updated to reflect these new API paths.

2. Basic Web Interface:
   - A simple web interface has been added to interact with the To-Do API.
   - Static files (HTML, CSS, JavaScript) are served from the `todo_backend/static` directory.
   - The main `index.html` is served from the root path (/).
   - Static assets (CSS, JS) are served from `/static/...`.
   - The web UI allows you to view, add, and mark To-Do items as complete.
   - New routes and a file server have been configured in `todo_backend/src/lib.rs` to serve these files.