### PR TITLE
Fix: Pin diesel_cli version to 2.1.1 in Dockerfile

### DIFF
--- a/todo_backend/Dockerfile
+++ b/todo_backend/Dockerfile
@@ -5,7 +5,7 @@ FROM rust:1.75.0 AS builder
 
 # Install diesel_cli and system dependencies for compiling pq-sys
 RUN apt-get update && apt-get install -y libpq-dev     && rm -rf /var/lib/apt/lists/*
-RUN cargo install diesel_cli --no-default-features --features postgres
+RUN cargo install diesel_cli --version 2.1.1 --no-default-features --features postgres
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The previous Dockerfile was failing to build because the latest version of diesel_cli (2.2.10) requires rustc 1.78.0 or newer, but the Docker image uses rustc 1.75.0.

This change pins diesel_cli to version 2.1.1, which is compatible with rustc 1.75.0, resolving the build error.