### PR TITLE
Fix: Ensure app service is healthy and migrations run before tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,19 +33,21 @@ jobs:
         INTERVAL=10 # Check every 10 seconds
         ELAPSED=0
         while true; do
-          DB_STATUS=$(docker compose ps db | grep 'healthy' | wc -l)
-          # APP_STATUS=$(docker compose ps app | grep 'healthy' | wc -l) # If app has healthcheck
-          # For now, we assume app starts if DB is healthy and migrations run
-          # If app had its own healthcheck in docker-compose.yml, we'd check it too.
+          DB_STATUS=$(docker compose ps db | grep 'healthy' | wc -l || true) # Ensure command doesn't fail if no match
+          APP_STATUS=$(docker compose ps app | grep 'healthy' | wc -l || true) # Ensure command doesn't fail if no match
 
-          if [ "$DB_STATUS" -ge 1 ]; then
-            echo "Database service is healthy."
+          if [ "$DB_STATUS" -ge 1 ] && [ "$APP_STATUS" -ge 1 ]; then
+            echo "Database and Application services are healthy."
             break
+          else
+            echo "DB Status: $DB_STATUS, App Status: $APP_STATUS"
           fi
 
           if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
             echo "Timeout waiting for services to become healthy."
+            echo "--- DB Logs ---"
             docker compose logs db
+            echo "--- App Logs ---"
             docker compose logs app
             exit 1
           fi
@@ -54,9 +56,10 @@ jobs:
           echo "Still waiting... ($ELAPSED/$TIMEOUT seconds)"
         done
 
-    - name: Run Database Migrations
-      run: docker compose exec -T app diesel migration run
-      # The -T option disables pseudo-tty allocation, which is recommended for automated scripts.
+    # Migrations are now handled by the entrypoint.sh script in the app container
+    # - name: Run Database Migrations
+    #   run: docker compose exec -T app diesel migration run
+    #   # The -T option disables pseudo-tty allocation, which is recommended for automated scripts.
 
     - name: Run tests
       run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,12 @@ services:
       ROCKET_ADDRESS: "0.0.0.0" # Important for Rocket to bind to all interfaces in Docker
       DATABASE_URL: "postgres://myuser:mypassword@db:5432/todo_db" # Connect to 'db' service on port 5432
       # ROCKET_LOG_LEVEL: "debug" # Optional: for more verbose logging
+    healthcheck:
+      test: ["CMD-SHELL", "curl http://localhost:8000/api/todos && exit 0 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s # Give the app some time to start before first health check
     # Add a command to run migrations before starting the app server
     # This requires diesel_cli to be available in the final image, or a separate migration script.
     # For simplicity, we'll assume the app runs migrations on startup if configured to do so.

--- a/todo_backend/Dockerfile
+++ b/todo_backend/Dockerfile
@@ -37,11 +37,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry     --mount=type=cache,t
 FROM debian:bullseye-slim
 
 # Install runtime dependencies (libpq for PostgreSQL client)
-RUN apt-get update && apt-get install -y libpq5 ca-certificates     && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y libpq5 ca-certificates curl     && rm -rf /var/lib/apt/lists/*
 
 # Copy the compiled binary and diesel_cli from the builder stage
 COPY --from=builder /usr/local/bin/todo_backend_server /usr/local/bin/todo_backend_server
 COPY --from=builder /usr/local/cargo/bin/diesel /usr/local/bin/diesel
+COPY todo_backend/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Copy static files if your application serves them
 # COPY todo_backend/static /app/static
@@ -49,9 +50,12 @@ COPY --from=builder /usr/local/cargo/bin/diesel /usr/local/bin/diesel
 # Set working directory
 WORKDIR /app
 
+# Ensure entrypoint script is executable
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 # Expose the port the app runs on (Rocket default is 8000)
 EXPOSE 8000
 
 # Command to run the application
 # The DATABASE_URL will be provided by docker-compose
-CMD ["/usr/local/bin/todo_backend_server"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/todo_backend/entrypoint.sh
+++ b/todo_backend/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+# Run database migrations
+echo "Running database migrations..."
+/usr/local/bin/diesel migration run
+
+# Start the main application
+echo "Starting application..."
+exec /usr/local/bin/todo_backend_server


### PR DESCRIPTION
The CI was failing because the 'app' service was not guaranteed to be running when the 'diesel migration run' command was executed.

This commit introduces the following changes:
1.  An `entrypoint.sh` script is added to the `todo_backend`. This script first runs `diesel migration run` and then starts the `todo_backend_server`.
2.  The `todo_backend/Dockerfile` is updated to use this `entrypoint.sh` and also installs `curl` for health checking.
3.  The `docker-compose.yml` is updated to include a healthcheck for the `app` service. This healthcheck uses `curl` to verify the app is responding before Docker marks it as healthy. A `start_period` is also added.
4.  The GitHub Actions workflow (`.github/workflows/rust.yml`) is updated:
    - The explicit `docker compose exec ... diesel migration run` command is removed, as migrations are now handled by the entrypoint.
    - The health check loop in the workflow is updated to wait for both the `db` and `app` services to report a healthy status before proceeding.

These changes make the service startup sequence more robust and should resolve the CI failures related to the app service not being ready.