### PR TITLE
Fix: Resolve GLIBC incompatibility and Docker Compose warnings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 # docker-compose.yml
-version: '3.8'
 
 services:
   db:

--- a/todo_backend/Dockerfile
+++ b/todo_backend/Dockerfile
@@ -1,7 +1,7 @@
 # todo_backend/Dockerfile
 
 # --- Builder Stage ---
-FROM rust:latest AS builder
+FROM rust:1.77-bullseye-slim AS builder
 RUN rustup update stable
 
 # Install diesel_cli and system dependencies for compiling pq-sys


### PR DESCRIPTION
This commit addresses two issues:

1.  Resolves a GLIBC incompatibility issue for the `diesel_cli` binary in the `todo_rust_app` service. The Dockerfile's builder stage was changed from `rust:latest` to `rust:1.77-bullseye-slim`. This ensures that `diesel_cli` is compiled with a GLIBC version that is compatible with the final `debian:bullseye-slim` runtime image, preventing errors during database migrations.

2.  Removes the obsolete `version` attribute from the `docker-compose.yml` file. This eliminates warning messages during `docker-compose up` and aligns the file with current Docker Compose specifications.

These changes should allow the application to build and start correctly within the Docker environment.