### PR TITLE
Fix: Update Rust Docker image tag in Dockerfile

### DIFF
--- a/todo_backend/Dockerfile
+++ b/todo_backend/Dockerfile
@@ -1,7 +1,7 @@
 # todo_backend/Dockerfile
 
 # --- Builder Stage ---
-FROM rust:1.77-bullseye-slim AS builder
+FROM rust:1.77-bullseye AS builder
 RUN rustup update stable
 
 # Install diesel_cli and system dependencies for compiling pq-sys


### PR DESCRIPTION
The previous tag, rust:1.77-bullseye-slim, was not found, causing Docker builds to fail. This change updates the tag to rust:1.77-bullseye.

This should resolve the error:
"failed to solve: rust:1.77-bullseye-slim: failed to resolve source metadata for docker.io/library/rust:1.77-bullseye-slim: docker.io/library/rust:1.77-bullseye-slim: not found"