### PR TITLE
Fix: Update Rust version to 1.82

### DIFF
--- a/todo_backend/Dockerfile
+++ b/todo_backend/Dockerfile
@@ -1,7 +1,7 @@
 # todo_backend/Dockerfile
 
 # --- Builder Stage ---
-FROM rust:1.77-bullseye AS builder
+FROM rust:1.82-bullseye AS builder
 RUN rustup update stable
 
 # Install diesel_cli and system dependencies for compiling pq-sys


### PR DESCRIPTION
The build was failing because the `icu_properties_data` package requires Rustc 1.82 or newer, while the currently active Rustc version was 1.77.2. This commit updates the Rust version in the Dockerfile to 1.82 to resolve the build error.