### PR TITLE
Fix: Resolve test failures due to Docker networking

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 env:
-  NETWORK_NAME: todo-network
+  COMPOSE_PROJECT_NAME: todo_project # Used by docker-compose to prefix network names
 
 jobs:
   build_and_test_dockerized:
@@ -21,37 +21,32 @@ jobs:
         docker --version
         docker compose version
 
-    - name: Create custom Docker network
-      run: docker network create $NETWORK_NAME
-
     - name: Build builder image
+      # This image is used by the test_runner service defined in docker-compose.yml (in the next step)
+      # and also by the app service.
       run: docker build --target builder -t todo-builder -f todo_backend/Dockerfile .
 
     - name: Start db service
-      # We only need the db service for the test phase.
-      # It will be connected to the custom network so the test container can reach it.
-      run: |
-        docker compose up -d db
-        docker network connect $NETWORK_NAME $(docker compose ps -q db)
+      # db service now uses the 'todo_network' defined in docker-compose.yml
+      run: docker compose up -d db
 
     - name: Wait for db service to be healthy
       run: |
         echo "Waiting for db service to become healthy..."
-        TIMEOUT=120 # 2 minutes timeout
-        INTERVAL=5 # Check every 5 seconds
+        TIMEOUT=120
+        INTERVAL=5
         ELAPSED=0
         while true; do
-          DB_STATUS=$(docker compose ps db | grep 'healthy' | wc -l || true)
-
+          # Ensure using COMPOSE_PROJECT_NAME for ps command if not globally set for all compose commands
+          DB_STATUS=$(docker compose -p ${COMPOSE_PROJECT_NAME} ps db | grep 'healthy' | wc -l || true)
           if [ "$DB_STATUS" -ge 1 ]; then
             echo "Database service is healthy."
             break
           fi
-
           if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
             echo "Timeout waiting for db service to become healthy."
             echo "--- DB Logs ---"
-            docker compose logs db
+            docker compose -p ${COMPOSE_PROJECT_NAME} logs db
             exit 1
           fi
           sleep $INTERVAL
@@ -59,19 +54,10 @@ jobs:
           echo "Still waiting for db... ($ELAPSED/$TIMEOUT seconds)"
         done
 
-    - name: Run tests in builder container
+    - name: Run tests using test_runner service
       run: |
-        echo "Running tests..."
-        # Mount the current directory to /usr/src/app in the container
-        # The builder Dockerfile has WORKDIR /usr/src/app
-        # DATABASE_URL uses 'db' as hostname, which resolves on the custom network
-        docker run --rm --network $NETWORK_NAME \
-          -v $(pwd):/usr/src/app \
-          -e DATABASE_URL="postgres://myuser:mypassword@db:5432/todo_db" \
-          -e RUST_LOG=debug \
-          -w /usr/src/app/todo_backend \
-          todo-builder \
-          cargo test -- --test-threads=1
+        echo "Running tests via docker compose..."
+        docker compose -p ${COMPOSE_PROJECT_NAME} run --rm test_runner
 
     - name: Build and start app service
       run: |
@@ -86,21 +72,19 @@ jobs:
       # This is a new step to ensure the final app is healthy before finishing.
       run: |
         echo "Waiting for app service to become healthy..."
-        TIMEOUT=120 # 2 minutes timeout
-        INTERVAL=5 # Check every 5 seconds
+        TIMEOUT=120
+        INTERVAL=5
         ELAPSED=0
         while true; do
-          APP_STATUS=$(docker compose ps app | grep 'healthy' | wc -l || true)
-
+          APP_STATUS=$(docker compose -p ${COMPOSE_PROJECT_NAME} ps app | grep 'healthy' | wc -l || true)
           if [ "$APP_STATUS" -ge 1 ]; then
             echo "Application service is healthy."
             break
           fi
-
           if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
             echo "Timeout waiting for app service to become healthy."
             echo "--- App Logs ---"
-            docker compose logs app
+            docker compose -p ${COMPOSE_PROJECT_NAME} logs app
             exit 1
           fi
           sleep $INTERVAL
@@ -108,8 +92,7 @@ jobs:
           echo "Still waiting for app... ($ELAPSED/$TIMEOUT seconds)"
         done
 
-    - name: Stop services and remove network
-      if: always() # Ensure cleanup happens even if previous steps fail
+    - name: Stop services
+      if: always()
       run: |
         docker compose down -v
-        docker network rm $NETWORK_NAME || true # Allow failure if network was already removed or never created

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,17 @@
 # docker-compose.yml
 
+version: '3.8'
+
 services:
   db:
     image: postgres:15-alpine
     container_name: todo_postgres_db
     environment:
-      POSTGRES_USER: myuser        # Changed from 'user' to 'myuser'
-      POSTGRES_PASSWORD: mypassword  # Changed from 'password' to 'mypassword'
+      POSTGRES_USER: myuser
+      POSTGRES_PASSWORD: mypassword
       POSTGRES_DB: todo_db
     ports:
-      - "5432:5432" # Expose port for local access if needed, not strictly necessary for inter-container communication
+      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -17,6 +19,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - todo_network
 
   app:
     build:
@@ -25,25 +29,40 @@ services:
     container_name: todo_rust_app
     depends_on:
       db:
-        condition: service_healthy # Wait for db to be healthy
+        condition: service_healthy
     ports:
       - "8000:8000"
     environment:
-      ROCKET_ADDRESS: "0.0.0.0" # Important for Rocket to bind to all interfaces in Docker
-      DATABASE_URL: "postgres://myuser:mypassword@db:5432/todo_db" # Connect to 'db' service on port 5432
-      # ROCKET_LOG_LEVEL: "debug" # Optional: for more verbose logging
+      ROCKET_ADDRESS: "0.0.0.0"
+      DATABASE_URL: "postgres://myuser:mypassword@db:5432/todo_db"
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost:8000/api/todos && exit 0 || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
-      start_period: 10s # Give the app some time to start before first health check
-    # Add a command to run migrations before starting the app server
-    # This requires diesel_cli to be available in the final image, or a separate migration script.
-    # For simplicity, we'll assume the app runs migrations on startup if configured to do so.
-    # If not, migrations need to be run manually or via an entrypoint script.
-    # The current lib.rs does not automatically run migrations, so this would be a manual step
-    # or require adding migration running logic to main.rs or db.rs.
+      start_period: 10s
+    networks:
+      - todo_network
+
+  test_runner: # New service
+    image: todo-builder # This image must be built before running this service
+    container_name: todo_test_runner
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: "postgres://myuser:mypassword@db:5432/todo_db"
+      RUST_LOG: debug
+    working_dir: /usr/src/app/todo_backend
+    volumes:
+      - .:/usr/src/app
+    command: cargo test -- --test-threads=1
+    networks:
+      - todo_network
 
 volumes:
-  postgres_data: # Persists database data across container restarts
+  postgres_data:
+
+networks:
+  todo_network:
+    driver: bridge


### PR DESCRIPTION
The integration tests were failing in the CI environment due to issues with resolving the 'db' hostname. This was caused by inconsistent Docker networking configurations between the test runner and the database service.

This commit addresses the issue by:
1. Modifying `docker-compose.yml`:
    - Defined a common network (`todo_network`) for all services.
    - Added a `test_runner` service specifically for executing tests. This service uses the pre-built `todo-builder` image, connects to `todo_network`, and has the correct `DATABASE_URL`.
2. Updating the GitHub Actions workflow (`.github/workflows/rust.yml`):
    - Removed manual Docker network creation and connection.
    - Set `COMPOSE_PROJECT_NAME` to ensure predictable network names.
    - Changed the test execution step to use `docker compose run --rm test_runner`, leveraging the new service definition.

These changes ensure that the database service is consistently accessible to the test environment, resolving the hostname resolution errors and allowing the tests to run correctly.