### PR TITLE
Fix: Run database migrations before tests in CI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
     working_dir: /usr/src/app/todo_backend
     volumes:
       - .:/usr/src/app
-    command: cargo test -- --test-threads=1
+    command: sh -c "diesel migration run && cargo test -- --test-threads=1"
     networks:
       - todo_network
 


### PR DESCRIPTION
The `test_runner` service in `docker-compose.yml` was executing `cargo test` without ensuring that database migrations were applied first. This caused tests to fail with the error "relation 'users' does not exist" because the database schema was not initialized.

This commit modifies the `command` for the `test_runner` service to execute `diesel migration run` before running `cargo test`. This ensures that the database schema is properly set up in the test environment, allowing the tests to pass.